### PR TITLE
Change `psycopg2` to `psycopg2-binary` in setup requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         'cached_property >= 1.2.0',
         'python-dateutil',
-        'psycopg2',
+        'psycopg2-binary',
         'pytz',
         'sedate',
         'SQLAlchemy>=0.9',


### PR DESCRIPTION
Change the psycopg driver dependency to the one that includes the binary headers. This makes it easier to have postgres as a docker container while still running the main app in the host OS.